### PR TITLE
fixed a broken link

### DIFF
--- a/Lila_HD/devices/scalable/uninterruptible-power-supply
+++ b/Lila_HD/devices/scalable/uninterruptible-power-supply
@@ -1,1 +1,1 @@
-scalable/gnome-dev-battery.svg
+gnome-dev-battery.svg


### PR DESCRIPTION
Ho aggiustato un collegamento simbolico sbagliato, che sta dando problemi nella compilazione dei pacchetti rpm sull'OBS, [qui](https://build.opensuse.org/package/live_build_log/home:Pival81/lila-hd-icon-theme/openSUSE_Tumbleweed/x86_64)